### PR TITLE
Fixed K/n_samples in expected gradients

### DIFF
--- a/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
+++ b/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
@@ -636,7 +636,7 @@
     "            gradients = torch.autograd.grad(y[spatial_focus, temporal_focus, :], curr_x, torch.ones_like(y[spatial_focus, temporal_focus, :]))\n",
     "\n",
     "        if k == 0:\n",
-    "            expected_gradients = x_diff*gradients[0] * 1/k\n",
+    "            expected_gradients = x_diff*gradients[0] * 1/\n",
     "        else:\n",
     "            expected_gradients = expected_gradients + ((x_diff*gradients[0]) * 1/n_samples)\n",
     "    return(expected_gradients)"

--- a/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
+++ b/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
@@ -636,7 +636,7 @@
     "            gradients = torch.autograd.grad(y[spatial_focus, temporal_focus, :], curr_x, torch.ones_like(y[spatial_focus, temporal_focus, :]))\n",
     "\n",
     "        if k == 0:\n",
-    "            expected_gradients = x_diff*gradients[0] * 1/\n",
+    "            expected_gradients = x_diff*gradients[0] * 1/n_samples\n",
     "        else:\n",
     "            expected_gradients = expected_gradients + ((x_diff*gradients[0]) * 1/n_samples)\n",
     "    return(expected_gradients)"

--- a/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
+++ b/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
@@ -636,9 +636,9 @@
     "            gradients = torch.autograd.grad(y[spatial_focus, temporal_focus, :], curr_x, torch.ones_like(y[spatial_focus, temporal_focus, :]))\n",
     "\n",
     "        if k == 0:\n",
-    "            expected_gradients = x_diff*gradients[0] * 1/K\n",
+    "            expected_gradients = x_diff*gradients[0] * 1/k\n",
     "        else:\n",
-    "            expected_gradients = expected_gradients + ((x_diff*gradients[0]) * 1/K)\n",
+    "            expected_gradients = expected_gradients + ((x_diff*gradients[0]) * 1/n_samples)\n",
     "    return(expected_gradients)"
    ]
   },
@@ -1142,7 +1142,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
+++ b/prototyping_notebooks/03_07_RGCN_CustomBackwardOpt_RiverDl.ipynb
@@ -692,7 +692,6 @@
    "source": [
     "# some value setting\n",
     "x = torch.from_numpy(river_dl['x_trn']).float()[:, -180:, :7]\n",
-    "K = 200 # EG steps\n",
     "\n",
     "# calculate attribution\n",
     "EG_vals = expected_gradients(x[-455:, -180:], y[-455:, -180:], x[:, -180:, :7], adj_matrix, model,\n",


### PR DESCRIPTION
@jdiaz4302, was just looking through  the backwards optimization notebook and noticed some errors in the expected gradients function.  Unless I'm mistaken `K` should be `n_samples` on line 639 and 641.  Just wanted to ping ya in case this is copy paste from elsewhere! 